### PR TITLE
Revert "Use the previous docker version, current version is not working"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ cat > docker-compose.yaml <<DOCKER
 version: '3'
 services:
   v2ray:
-    image: v2fly/v2fly-core:v4.45.2
+    image: v2fly/v2fly-core
     restart: always
     network_mode: host
     environment:


### PR DESCRIPTION
Using entrypoint in docker-compose is a better solution than downgrading v2ray-core 